### PR TITLE
move grid variable inside useEffect 

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ import MagicGrid from "magic-grid"
 
 const MagicGridWrapper = ({ children, ...props }) => {
   const container = useRef(null)
-  let grid = null
 
   useEffect(() => {
+    let grid = null
     let timeout
     // magic-grid handles resizing via its own `listen` method
     // unfortunately event listener it creates is not being cleaned up


### PR DESCRIPTION
since is only usede there and to avoid fix this React `warning`:

> Assignments to the 'grid' variable from inside React Hook useEffect will be lost after each render. To preserve the value over time, store it in a useRef Hook and keep the mutable value in the '.current' property. Otherwise, you can move this variable directly inside useEffect  react-hooks/exhaustive-deps