### PR TITLE
allow imperative handling of resizing by exporting positionItems through forwardRef

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,3 +26,23 @@ const Cards = ({ cards }) => (
 ### Props
 
 Supports all options in [Magic-Grid's config](https://github.com/e-oj/Magic-Grid#magicgridconfig).
+
+### Repositioning
+
+Supports imperative repositioning through ref forwarding.
+
+```jsx
+import MagicGrid from "react-magic-grid"
+
+const ResizableComponent = ({ cards }) => {
+  const gridRef = React.useRef()
+
+  // Can use gridRef.current.positionItems() to reposizion.
+
+  return (
+    <MagicGrid items={cards.length} ref={gridRef}>
+      {/* card rendering code */}
+    </MagicGrid>
+  )
+}
+```

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@ import MagicGrid from "react-magic-grid"
 const ResizableComponent = ({ cards }) => {
   const gridRef = React.useRef()
 
-  // Can use gridRef.current.positionItems() to reposizion.
+  // Can use gridRef.current.positionItems() to reposition.
 
   return (
     <MagicGrid items={cards.length} ref={gridRef}>

--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
-import React, { useEffect, useRef } from "react"
+import React, {
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+} from "react"
 import PropTypes from "prop-types"
 import MagicGrid from "magic-grid"
 
-const MagicGridWrapper = ({ children, ...props }) => {
+const MagicGridWrapper = ({ children, ...props }, ref) => {
   const container = useRef(null)
+  const grid = useRef(null)
 
   useEffect(() => {
-    let grid = null
     let timeout
     // magic-grid handles resizing via its own `listen` method
     // unfortunately event listener it creates is not being cleaned up
@@ -15,22 +20,28 @@ const MagicGridWrapper = ({ children, ...props }) => {
     const resize = () => {
       if (!timeout)
         timeout = setTimeout(() => {
-          grid && grid.positionItems()
+          grid.current && grid.current.positionItems()
           timeout = null
         }, 200)
     }
 
-    if (!grid) {
-      grid = new MagicGrid({ container: container.current, ...props })
+    if (!grid.current) {
+      grid.current = new MagicGrid({ container: container.current, ...props })
       window.addEventListener("resize", resize)
     }
 
-    grid.positionItems()
+    grid.current.positionItems()
 
     return () => {
       window.removeEventListener("resize", resize)
     }
   })
+
+  useImperativeHandle(ref, () => ({
+    positionItems: () => {
+      grid.current && grid.current.positionItems()
+    },
+  }))
 
   return <div ref={container}>{children}</div>
 }
@@ -39,4 +50,4 @@ MagicGridWrapper.propTypes = {
   children: PropTypes.arrayOf(PropTypes.node),
 }
 
-export default MagicGridWrapper
+export default forwardRef(MagicGridWrapper)

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
 import React, {
   useEffect,
   useRef,
+  createRef,
   useImperativeHandle,
   forwardRef,
 } from "react"
 import PropTypes from "prop-types"
 import MagicGrid from "magic-grid"
 
-const MagicGridWrapper = ({ children, ...props }, ref) => {
+const MagicGridWrapper = forwardRef(({ children, ...props }, ref) => {
   const container = useRef(null)
-  const grid = useRef(null)
+  const grid = createRef()
 
   useEffect(() => {
     let timeout
@@ -44,10 +45,10 @@ const MagicGridWrapper = ({ children, ...props }, ref) => {
   }))
 
   return <div ref={container}>{children}</div>
-}
+})
 
 MagicGridWrapper.propTypes = {
   children: PropTypes.arrayOf(PropTypes.node),
 }
 
-export default forwardRef(MagicGridWrapper)
+export default MagicGridWrapper

--- a/index.story.js
+++ b/index.story.js
@@ -8,6 +8,7 @@ const cards = [1, 2, 3, 4, 5, 6, 7, 9]
 
 const Card = ({ item }) => (
   <div
+    className={"card"}
     style={{
       width: `${100 / 4}%`,
       minWidth: 200,
@@ -43,3 +44,34 @@ storiesOf("MagicGrid", module)
       ))}
     </MagicGrid>
   ))
+  .add("reposition", () => {
+    const gridRef = React.useRef()
+
+    return (
+      <div>
+        <div>
+          <input
+            type="button"
+            onClick={() => {
+              document.querySelectorAll(".card").forEach(card => {
+                card.style.height = `${
+                  Math.floor(Math.random() * (300 - 100 + 1)) + 100
+                }px`
+              })
+            }}
+            value="change size"
+          />
+          <input
+            type="button"
+            onClick={() => gridRef.current.positionItems()}
+            value="reposition"
+          />
+        </div>
+        <MagicGrid items={cards.length} gutter={0} ref={gridRef}>
+          {cards.map(item => (
+            <Card key={item} i={item} />
+          ))}
+        </MagicGrid>
+      </div>
+    )
+  })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5463,6 +5463,7 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
@@ -5856,7 +5857,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -6476,7 +6478,8 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "bluebird": {
       "version": "3.7.2",
@@ -7033,6 +7036,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
@@ -7052,7 +7056,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11232,6 +11237,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -12455,6 +12461,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -14722,6 +14729,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
@@ -14732,19 +14740,22 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -14763,6 +14774,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -14774,6 +14786,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -14789,6 +14802,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -14798,6 +14812,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -14807,6 +14822,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -14816,6 +14832,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -14827,6 +14844,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -14836,6 +14854,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -14847,6 +14866,7 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -14857,7 +14877,8 @@
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -14866,6 +14887,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -14882,6 +14904,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -14891,6 +14914,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -14902,6 +14926,7 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -14914,6 +14939,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -14925,6 +14951,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -14934,6 +14961,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -14943,6 +14971,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -14954,6 +14983,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -14963,6 +14993,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -14973,19 +15004,22 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -15232,7 +15266,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "renderkid": {
       "version": "2.0.3",
@@ -17327,7 +17362,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,12 @@ export default [
       commonjs({
         include: "node_modules/**",
         namedExports: {
-          "node_modules/react/index.js": ["useRef", "useEffect"],
+          "node_modules/react/index.js": [
+            "useRef",
+            "useEffect",
+            "useImperativeHandle",
+            "forwardRef",
+          ],
         },
       }),
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,7 @@ export default [
             "useEffect",
             "useImperativeHandle",
             "forwardRef",
+            "createRef",
           ],
         },
       }),


### PR DESCRIPTION
I found myself needing to imperatively reposition elements after images/embeds have finished loading. To do this, I exported the appropriate method through ref forwarding and exposed it to the parent. 

Would love to make this available to other users of the library. This is not a breaking change.