### PR TITLE
Add support for `as` prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react"
 import PropTypes from "prop-types"
 import MagicGrid from "magic-grid"
 
-const MagicGridWrapper = ({ children, ...props }) => {
+const MagicGridWrapper = ({ as: Component = "div", children, ...props }) => {
   const container = useRef(null)
 
   useEffect(() => {
@@ -32,10 +32,11 @@ const MagicGridWrapper = ({ children, ...props }) => {
     }
   })
 
-  return <div ref={container}>{children}</div>
+  return <Component ref={container}>{children}</Component>
 }
 
 MagicGridWrapper.propTypes = {
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
   children: PropTypes.arrayOf(PropTypes.node),
 }
 

--- a/index.story.js
+++ b/index.story.js
@@ -1,45 +1,67 @@
 import React from "react"
-import PropTypes from "prop-types"
 import { storiesOf } from "@storybook/react"
 
 import MagicGrid from "./index"
 
 const cards = [1, 2, 3, 4, 5, 6, 7, 9]
 
-const Card = ({ item }) => (
-  <div
-    style={{
-      width: `${100 / 4}%`,
-      minWidth: 200,
-      height: Math.floor(Math.random() * (300 - 100 + 1)) + 100,
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      boxSizing: "border-box",
-      padding: "1rem",
-      backgroundColor: "antiquewhite",
-      borderRadius: "8px",
-      border: "1px solid brown",
-    }}
-  >
-    {item}
-  </div>
-)
+const getStyle = () => ({
+  margin: 0,
+  padding: 0,
+  width: `${100 / 4}%`,
+  minWidth: 200,
+  height: Math.floor(Math.random() * (300 - 100 + 1)) + 100,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  boxSizing: "border-box",
+  padding: "1rem",
+  backgroundColor: "antiquewhite",
+  borderRadius: "8px",
+  border: "1px solid brown",
+})
 
-Card.propTypes = { item: PropTypes.number }
+// remember to forward ref when using custom components
+const CustomUl = React.forwardRef((props, ref) =>
+  <ul ref={ref} style={{ margin: 0, padding: 0, background: "#111" }} {...props} />
+)
 
 storiesOf("MagicGrid", module)
   .add("default", () => (
     <MagicGrid items={cards.length} gutter={0}>
       {cards.map(item => (
-        <Card key={item} item={item} />
+        <div key={item} style={getStyle()}>
+          {item}
+        </div>
+
       ))}
     </MagicGrid>
   ))
   .add("animated", () => (
     <MagicGrid items={cards.length} gutter={0} animate={true}>
       {cards.map(item => (
-        <Card key={item} i={item} />
+        <div key={item} style={getStyle()}>
+          {item}
+        </div>
       ))}
     </MagicGrid>
   ))
+  .add("`as` prop", () => (
+    <MagicGrid as="ul" items={cards.length} gutter={0}>
+      {cards.map(item => (
+        <li key={item} style={getStyle()}>
+          {item}
+        </li>
+      ))}
+    </MagicGrid>
+  ))
+  .add("`as` prop custom component", () => (
+    <MagicGrid as={CustomUl} items={cards.length} gutter={0}>
+      {cards.map(item => (
+        <li key={item} style={getStyle()}>
+          {item}
+        </li>
+      ))}
+    </MagicGrid>
+  ))
+


### PR DESCRIPTION
Allows rendering with a root element different than the default `div`.
Supports custom components as well, they just need ref being forwarded.
Closes #2